### PR TITLE
Fixed Timing Issue

### DIFF
--- a/CEMovieMaker/CEMovieMaker.m
+++ b/CEMovieMaker/CEMovieMaker.m
@@ -79,7 +79,7 @@
                     if (i == 0) {
                         [self.bufferAdapter appendPixelBuffer:sampleBuffer withPresentationTime:kCMTimeZero];
                     }else{
-                        CMTime lastTime = CMTimeMake(i, self.frameTime.timescale);
+                        CMTime lastTime = CMTimeMake(i-1, self.frameTime.timescale);
                         CMTime presentTime = CMTimeAdd(lastTime, self.frameTime);
                         [self.bufferAdapter appendPixelBuffer:sampleBuffer withPresentationTime:presentTime];
                     }


### PR DESCRIPTION
This is a minor timing issue, but I found that with your currently implementation, the first image would last 2x as long as it should.  The difference is slight, but by changing this one line, each image has the same length in the resulting video.

You can check out the difference with these two examples:

1) Without the correction: https://dl.dropboxusercontent.com/u/1000620/01_with_delay.mov (you can notice a slight delay as the first image is longer than it should be)
2) With the correction: https://dl.dropboxusercontent.com/u/1000620/02_without_delay.mov (all images last for the same amount of time)
