### PR TITLE
Allow using NSURLs for images instead of UIImage's

### DIFF
--- a/CEMovieMaker/CEMovieMaker.h
+++ b/CEMovieMaker/CEMovieMaker.h
@@ -23,6 +23,7 @@ typedef void(^CEMovieMakerCompletion)(NSURL *fileURL);
 @property (nonatomic, copy) CEMovieMakerCompletion completionBlock;
 
 - (instancetype)initWithSettings:(NSDictionary *)videoSettings;
+- (void) createMovieFromImageURLs:(NSArray<NSURL*>*)urls withCompletion:(CEMovieMakerCompletion)completion;
 - (void)createMovieFromImages:(NSArray *)images withCompletion:(CEMovieMakerCompletion)completion;
 
 + (NSDictionary *)videoSettingsWithCodec:(NSString *)codec withWidth:(CGFloat)width andHeight:(CGFloat)height;

--- a/CEMovieMaker/CEMovieMaker.h
+++ b/CEMovieMaker/CEMovieMaker.h
@@ -12,6 +12,15 @@
 
 typedef void(^CEMovieMakerCompletion)(NSURL *fileURL);
 
+#if __has_feature(objc_generics) || __has_extension(objc_generics)
+    #define CE_GENERIC_URL <NSURL *>
+    #define CE_GENERIC_IMAGE <UIImage *>
+#else
+    #define CE_GENERIC_URL
+    #define CE_GENERIC_IMAGE
+#endif
+
+
 @interface CEMovieMaker : NSObject
 
 @property (nonatomic, strong) AVAssetWriter *assetWriter;
@@ -23,8 +32,8 @@ typedef void(^CEMovieMakerCompletion)(NSURL *fileURL);
 @property (nonatomic, copy) CEMovieMakerCompletion completionBlock;
 
 - (instancetype)initWithSettings:(NSDictionary *)videoSettings;
-- (void) createMovieFromImageURLs:(NSArray<NSURL*>*)urls withCompletion:(CEMovieMakerCompletion)completion;
-- (void)createMovieFromImages:(NSArray *)images withCompletion:(CEMovieMakerCompletion)completion;
+- (void)createMovieFromImageURLs:(NSArray CE_GENERIC_URL*)urls withCompletion:(CEMovieMakerCompletion)completion;
+- (void)createMovieFromImages:(NSArray CE_GENERIC_IMAGE*)images withCompletion:(CEMovieMakerCompletion)completion;
 
 + (NSDictionary *)videoSettingsWithCodec:(NSString *)codec withWidth:(CGFloat)width andHeight:(CGFloat)height;
 

--- a/CEMovieMaker/CEMovieMaker.m
+++ b/CEMovieMaker/CEMovieMaker.m
@@ -55,14 +55,14 @@ typedef UIImage*(^CEMovieMakerUIImageExtractor)(NSObject* inputObject);
     return self;
 }
 
-- (void) createMovieFromImageURLs:(NSArray<NSURL*>*)urls withCompletion:(CEMovieMakerCompletion)completion;
+- (void) createMovieFromImageURLs:(NSArray CE_GENERIC_URL*)urls withCompletion:(CEMovieMakerCompletion)completion;
 {
     [self createMovieFromSource:urls extractor:^UIImage *(NSObject *inputObject) {
         return [UIImage imageWithData: [NSData dataWithContentsOfURL:((NSURL*)inputObject)]];
     } withCompletion:completion];
 }
 
-- (void) createMovieFromImages:(NSArray *)images withCompletion:(CEMovieMakerCompletion)completion;
+- (void) createMovieFromImages:(NSArray CE_GENERIC_IMAGE *)images withCompletion:(CEMovieMakerCompletion)completion;
 {
     [self createMovieFromSource:images extractor:^UIImage *(NSObject *inputObject) {
         return (UIImage*)inputObject;

--- a/CEMovieMaker/CEMovieMaker.m
+++ b/CEMovieMaker/CEMovieMaker.m
@@ -69,7 +69,7 @@ typedef UIImage*(^CEMovieMakerUIImageExtractor)(NSObject* inputObject);
     } withCompletion:completion];
 }
 
-- (void)createMovieFromSource:(NSArray *)images extractor:(CEMovieMakerUIImageExtractor)extractor withCompletion:(CEMovieMakerCompletion)completion;
+- (void) createMovieFromSource:(NSArray *)images extractor:(CEMovieMakerUIImageExtractor)extractor withCompletion:(CEMovieMakerCompletion)completion;
 {
     self.completionBlock = completion;
     

--- a/CEMovieMaker/CEMovieMaker.m
+++ b/CEMovieMaker/CEMovieMaker.m
@@ -8,6 +8,8 @@
 
 #import "CEMovieMaker.h"
 
+typedef UIImage*(^CEMovieMakerUIImageExtractor)(NSObject* inputObject);
+
 @implementation CEMovieMaker
 
 - (instancetype)initWithSettings:(NSDictionary *)videoSettings;
@@ -53,7 +55,21 @@
     return self;
 }
 
-- (void)createMovieFromImages:(NSArray *)images withCompletion:(CEMovieMakerCompletion)completion;
+- (void) createMovieFromImageURLs:(NSArray<NSURL*>*)urls withCompletion:(CEMovieMakerCompletion)completion;
+{
+    [self createMovieFromSource:urls extractor:^UIImage *(NSObject *inputObject) {
+        return [UIImage imageWithData: [NSData dataWithContentsOfURL:((NSURL*)inputObject)]];
+    } withCompletion:completion];
+}
+
+- (void) createMovieFromImages:(NSArray *)images withCompletion:(CEMovieMakerCompletion)completion;
+{
+    [self createMovieFromSource:images extractor:^UIImage *(NSObject *inputObject) {
+        return (UIImage*)inputObject;
+    } withCompletion:completion];
+}
+
+- (void)createMovieFromSource:(NSArray *)images extractor:(CEMovieMakerUIImageExtractor)extractor withCompletion:(CEMovieMakerCompletion)completion;
 {
     self.completionBlock = completion;
     
@@ -72,8 +88,13 @@
                 break;
             }
             if ([self.writerInput isReadyForMoreMediaData]) {
-                
-                CVPixelBufferRef sampleBuffer = [self newPixelBufferFromCGImage:[[images objectAtIndex:i] CGImage]];
+                UIImage* img = extractor([images objectAtIndex:i]);
+                if (img == nil) {
+                    i++;
+                    NSLog(@"Warning: could not extract one of the frames");
+                    continue;
+                }
+                CVPixelBufferRef sampleBuffer = [self newPixelBufferFromCGImage:[img CGImage]];
                 
                 if (sampleBuffer) {
                     if (i == 0) {
@@ -99,6 +120,7 @@
         CVPixelBufferPoolRelease(self.bufferAdapter.pixelBufferPool);
     }];
 }
+
 
 - (CVPixelBufferRef)newPixelBufferFromCGImage:(CGImageRef)image
 {


### PR DESCRIPTION
For any video that is worth encoding, lower-end devices may crash if we're trying to do everything in memory. 

I needed this for my project, and thought it would be useful. 
