### PR TITLE
Solve some memory issues with image extraction

### DIFF
--- a/CEMovieMaker/CEMovieMaker.m
+++ b/CEMovieMaker/CEMovieMaker.m
@@ -88,14 +88,18 @@ typedef UIImage*(^CEMovieMakerUIImageExtractor)(NSObject* inputObject);
                 break;
             }
             if ([self.writerInput isReadyForMoreMediaData]) {
-                UIImage* img = extractor([images objectAtIndex:i]);
-                if (img == nil) {
-                    i++;
-                    NSLog(@"Warning: could not extract one of the frames");
-                    continue;
+
+                UIImage* img;
+                CVPixelBufferRef sampleBuffer;
+                @autoreleasepool {
+                    img = extractor([images objectAtIndex:i]);
+                    if (img == nil) {
+                        i++;
+                        NSLog(@"Warning: could not extract one of the frames");
+                        continue;
+                    }
+                    sampleBuffer = [self newPixelBufferFromCGImage:[img CGImage]];
                 }
-                CVPixelBufferRef sampleBuffer = [self newPixelBufferFromCGImage:[img CGImage]];
-                
                 if (sampleBuffer) {
                     if (i == 0) {
                         [self.bufferAdapter appendPixelBuffer:sampleBuffer withPresentationTime:kCMTimeZero];

--- a/CEMovieMaker/CEMovieMaker.m
+++ b/CEMovieMaker/CEMovieMaker.m
@@ -89,10 +89,9 @@ typedef UIImage*(^CEMovieMakerUIImageExtractor)(NSObject* inputObject);
             }
             if ([self.writerInput isReadyForMoreMediaData]) {
 
-                UIImage* img;
                 CVPixelBufferRef sampleBuffer;
                 @autoreleasepool {
-                    img = extractor([images objectAtIndex:i]);
+                    UIImage* img = extractor([images objectAtIndex:i]);
                     if (img == nil) {
                         i++;
                         NSLog(@"Warning: could not extract one of the frames");


### PR DESCRIPTION
Reading from the disk worked great for medium numbers of images, but I ran into this issue when I tried to go extra (1000+ images). 

Turns out the UIImage that we got the pixelbuffer from was not being released early enough, leading to memory issues. Added an autoreleasepool to fix these. 

Test Plan: I profiled our video code with a large number of files in instruments. I found this reduces the memory footprint quite a lot. 
